### PR TITLE
remove beta document-level approach, persist purely line embeddings as a new beta approach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "semtools"
-version = "1.3.0-beta.1"
+version = "1.3.0-beta.2"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semtools"
-version = "1.3.0-beta.1"
+version = "1.3.0-beta.2"
 edition = "2024"
 license = "MIT"
 description = "Semantic search and document parsing tools for the command line"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@llamaindex/semtools",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "description": "Semantic search and document parsing tools for the command line (Rust-backed, npm-distributed)",
   "license": "MIT",
   "author": "LlamaIndex",

--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -3,14 +3,13 @@ use clap::Parser;
 use model2vec_rs::model::StaticModel;
 use simsimd::SpatialSimilarity;
 use std::cmp::{max, min};
-use std::collections::HashMap;
 use std::fs::read_to_string;
 use std::io::{self, BufRead, IsTerminal};
 
 #[cfg(feature = "workspace")]
 use semtools::workspace::{
     Workspace,
-    store::{DocMeta, Store},
+    store::{DocMeta, Store, LineEmbedding, RankedLine},
 };
 
 const MODEL_NAME: &str = "minishlab/potion-multilingual-128M";
@@ -269,6 +268,52 @@ fn print_search_results(results: &[SearchResult]) {
     }
 }
 
+#[cfg(feature = "workspace")]
+fn print_workspace_search_results(ranked_lines: &[RankedLine], n_lines: usize) {
+    let is_tty = io::stdout().is_terminal();
+    
+    for ranked_line in ranked_lines {
+        let filename = &ranked_line.path;
+        let distance = ranked_line.distance;
+        let match_line_number = ranked_line.line_number as usize;
+        
+        // Calculate context range
+        let start = match_line_number.saturating_sub(n_lines);
+        let end = match_line_number + n_lines + 1;
+        
+        println!("{filename}:{start}::{end} ({distance})");
+
+        // For workspace results, we need to read the file to get context lines
+        // This is acceptable since we're only doing this for the final results
+        if let Ok(content) = std::fs::read_to_string(filename) {
+            let lines: Vec<&str> = content.lines().collect();
+            let actual_start = start.min(lines.len().saturating_sub(1));
+            let actual_end = end.min(lines.len());
+            
+            for (i, line) in lines[actual_start..actual_end].iter().enumerate() {
+                let line_number = actual_start + i;
+                
+                if line_number == match_line_number {
+                    if is_tty {
+                        // Highlight the matching line with yellow background and black text
+                        println!("\x1b[43m\x1b[30m{:4}: {}\x1b[0m", line_number + 1, line);
+                    } else {
+                        println!("{:4}: {}", line_number + 1, line);
+                    }
+                } else {
+                    // Regular context line
+                    println!("{:4}: {}", line_number + 1, line);
+                }
+            }
+        } else {
+            // Fallback: indicate that the file couldn't be read
+            println!("    [Error: Could not read file content]");
+        }
+        
+        println!(); // Empty line between results
+    }
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
 
@@ -320,7 +365,7 @@ fn main() -> Result<()> {
     // Handle file input with optional workspace integration
     #[cfg(feature = "workspace")]
     if Workspace::active().is_ok() {
-        // Workspace mode: implement two-stage retrieval
+        // Workspace mode: use persisted line embeddings for speed
         let ws = Workspace::open()?;
         let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
         let store = rt.block_on(Store::open(&ws.config.root_dir))?;
@@ -329,34 +374,29 @@ fn main() -> Result<()> {
         let doc_states = rt.block_on(analyze_document_states(&args.files, &store))?;
 
         // Step 2: Process documents that need embedding updates
+        let mut line_embeddings_to_upsert = Vec::new();
         let mut docs_to_upsert = Vec::new();
-        let mut doc_embeddings_to_upsert = Vec::new();
 
         for state in &doc_states {
             match state {
                 DocumentState::Changed(doc_info) | DocumentState::New(doc_info) => {
-                    // Generate document-level embedding (average of line embeddings)
+                    // Generate line-by-line embeddings and store them
                     if let Some(doc) = create_document_from_content(
                         doc_info.filename.clone(),
                         &doc_info.content,
                         &model,
                         args.ignore_case,
-                    ) && !doc.embeddings.is_empty()
-                    {
-                        let dim = doc.embeddings[0].len();
-                        let mut sum = vec![0.0f32; dim];
-                        for e in &doc.embeddings {
-                            for (i, v) in e.iter().enumerate() {
-                                sum[i] += *v;
-                            }
+                    ) {
+                        // Create LineEmbedding entries for each line
+                        for (line_idx, embedding) in doc.embeddings.iter().enumerate() {
+                            line_embeddings_to_upsert.push(LineEmbedding {
+                                path: doc_info.filename.clone(),
+                                line_number: line_idx as i32,
+                                embedding: embedding.clone(),
+                            });
                         }
-                        let count = doc.embeddings.len() as f32;
-                        for v in &mut sum {
-                            *v /= count;
-                        }
-
+                        // Also track document metadata for change detection
                         docs_to_upsert.push(doc_info.meta.clone());
-                        doc_embeddings_to_upsert.push(sum);
                     }
                 }
                 DocumentState::Unchanged(_) => {
@@ -365,75 +405,28 @@ fn main() -> Result<()> {
             }
         }
 
-        // Step 3: Update workspace with new/changed documents
+        // Step 3: Update workspace with new/changed line embeddings
+        if !line_embeddings_to_upsert.is_empty() {
+            rt.block_on(store.upsert_line_embeddings(&line_embeddings_to_upsert))?;
+        }
+        
+        // Also update document metadata for tracking changes
         if !docs_to_upsert.is_empty() {
-            rt.block_on(store.upsert_documents(&docs_to_upsert, &doc_embeddings_to_upsert))?;
+            rt.block_on(store.upsert_document_metadata(&docs_to_upsert))?;
         }
 
-        // Step 4: Two-stage retrieval if we have many documents
-        // Use doc_top_k as threshold for when to apply ANN filtering
-        let working_set_paths = if args.files.len() > ws.config.doc_top_k {
-            // Stage 1: ANN filter to get top documents from workspace
-            let candidates = rt
-                .block_on(store.ann_filter_top_k(
-                    &query_embedding,
-                    &args.files,
-                    ws.config.doc_top_k,
-                    ws.config.in_batch_size,
-                ))
-                .unwrap_or_default();
-            candidates.into_iter().map(|r| r.path).collect()
-        } else {
-            // Small dataset - use all files
-            args.files.clone()
-        };
+        // Step 4: Search line embeddings directly from the workspace
+        let max_distance = args.max_distance.map(|d| d as f32);
+        let ranked_lines = rt
+            .block_on(store.search_line_embeddings(
+                &query_embedding,
+                &args.files,
+                args.top_k,
+                max_distance,
+            ))?;
 
-        // Step 5: Generate line-by-line embeddings only for working set
-        // Reuse already-read content for Changed/New docs to avoid double reads
-        let mut content_cache: HashMap<&str, &str> = HashMap::new();
-        let mut owned_content_cache: HashMap<String, String> = HashMap::new();
-
-        for state in &doc_states {
-            match state {
-                DocumentState::Changed(info) | DocumentState::New(info) => {
-                    owned_content_cache.insert(info.filename.clone(), info.content.clone());
-                }
-                DocumentState::Unchanged(_) => {}
-            }
-        }
-
-        // Convert to &str cache for quick lookup
-        for (k, v) in &owned_content_cache {
-            content_cache.insert(k.as_str(), v.as_str());
-        }
-
-        let mut documents = Vec::new();
-        for file_path in &working_set_paths {
-            if let Some(content) = content_cache.get(file_path.as_str()) {
-                if let Some(doc) = create_document_from_content(
-                    file_path.clone(),
-                    content,
-                    &model,
-                    args.ignore_case,
-                ) {
-                    documents.push(doc);
-                }
-            } else {
-                let content = read_to_string(file_path)?;
-                if let Some(doc) = create_document_from_content(
-                    file_path.clone(),
-                    &content,
-                    &model,
-                    args.ignore_case,
-                ) {
-                    documents.push(doc);
-                }
-            }
-        }
-
-        // Step 6: Perform line-by-line search on working set
-        let search_results = search_documents(&documents, &query_embedding, &args);
-        print_search_results(&search_results);
+        // Step 5: Convert results to SearchResult format and print
+        print_workspace_search_results(&ranked_lines, args.n_lines);
     } else {
         perform_traditional_search(&args.files, &query_embedding, &model, &args)?;
     }
@@ -760,7 +753,6 @@ mod tests {
 
             // Insert documents with current metadata
             let mut docs = Vec::new();
-            let mut embeddings = Vec::new();
             for path in &file_paths {
                 let metadata = fs::metadata(path).unwrap();
                 let doc_meta = DocMeta {
@@ -774,9 +766,9 @@ mod tests {
                         .as_secs() as i64,
                 };
                 docs.push(doc_meta);
-                embeddings.push(vec![1.0, 2.0, 3.0, 4.0]); // Dummy embedding
+                // embeddings.push(vec![1.0, 2.0, 3.0, 4.0]); // Dummy embedding - not needed anymore
             }
-            store.upsert_documents(&docs, &embeddings).await.unwrap();
+            store.upsert_document_metadata(&docs).await.unwrap();
 
             // Analyze states - should all be unchanged
             let states = analyze_document_states(&file_paths, &store).await.unwrap();
@@ -803,7 +795,6 @@ mod tests {
                 .unwrap();
 
             let mut docs = Vec::new();
-            let mut embeddings = Vec::new();
             for path in &file_paths {
                 let doc_meta = DocMeta {
                     path: path.clone(),
@@ -811,9 +802,9 @@ mod tests {
                     mtime: 1000,    // Old timestamp
                 };
                 docs.push(doc_meta);
-                embeddings.push(vec![1.0, 2.0, 3.0, 4.0]); // Dummy embedding
+                // embeddings.push(vec![1.0, 2.0, 3.0, 4.0]); // Dummy embedding - not needed anymore
             }
-            store.upsert_documents(&docs, &embeddings).await.unwrap();
+            store.upsert_document_metadata(&docs).await.unwrap();
 
             // Analyze states - should all be changed
             let states = analyze_document_states(&file_paths, &store).await.unwrap();
@@ -851,9 +842,8 @@ mod tests {
                     .unwrap()
                     .as_secs() as i64,
             };
-            let embedding = vec![vec![1.0, 2.0, 3.0, 4.0]];
             store
-                .upsert_documents(&[doc_meta], &embedding)
+                .upsert_document_metadata(&[doc_meta])
                 .await
                 .unwrap();
 

--- a/src/workspace/store.rs
+++ b/src/workspace/store.rs
@@ -355,8 +355,14 @@ impl Store {
 
         // Build RecordBatch
         let id_array = Int32Array::from_iter_values(line_embeddings.iter().map(|le| le.id()));
-        let path_array = StringArray::from(line_embeddings.iter().map(|le| le.path.as_str()).collect::<Vec<_>>());
-        let line_number_array = Int32Array::from_iter_values(line_embeddings.iter().map(|le| le.line_number));
+        let path_array = StringArray::from(
+            line_embeddings
+                .iter()
+                .map(|le| le.path.as_str())
+                .collect::<Vec<_>>(),
+        );
+        let line_number_array =
+            Int32Array::from_iter_values(line_embeddings.iter().map(|le| le.line_number));
         let vector_array = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
             line_embeddings
                 .iter()
@@ -409,7 +415,6 @@ impl Store {
 
         Ok(())
     }
-
 
     /// Ensures vector index exists for line embeddings table
     async fn ensure_line_vector_index(&self) -> Result<()> {
@@ -671,12 +676,12 @@ impl Store {
                 if let Some(dist_array) = dist_col.as_any().downcast_ref::<Float32Array>() {
                     for i in 0..batch.num_rows() {
                         let distance = dist_array.value(i);
-                        if let Some(max_dist) = max_distance {
-                            if distance > max_dist {
-                                continue;
-                            }
+                        if let Some(max_dist) = max_distance
+                            && distance > max_dist
+                        {
+                            continue;
                         }
-                        
+
                         all_results.push(RankedLine {
                             path: path_array.value(i).to_string(),
                             line_number: line_number_array.value(i),
@@ -686,12 +691,12 @@ impl Store {
                 } else if let Some(dist_array) = dist_col.as_any().downcast_ref::<Float64Array>() {
                     for i in 0..batch.num_rows() {
                         let distance = dist_array.value(i) as f32;
-                        if let Some(max_dist) = max_distance {
-                            if distance > max_dist {
-                                continue;
-                            }
+                        if let Some(max_dist) = max_distance
+                            && distance > max_dist
+                        {
+                            continue;
                         }
-                        
+
                         all_results.push(RankedLine {
                             path: path_array.value(i).to_string(),
                             line_number: line_number_array.value(i),
@@ -898,8 +903,6 @@ mod tests {
         assert_eq!(remaining_paths.len(), 1);
         assert!(remaining_paths.contains(&"/test/doc2.txt".to_string()));
     }
-
-
 
     #[tokio::test]
     async fn test_upsert_replaces_existing() {

--- a/src/workspace/store.rs
+++ b/src/workspace/store.rs
@@ -787,13 +787,28 @@ mod tests {
     #[tokio::test]
     async fn test_upsert_documents_and_stats() {
         let (store, _temp_dir) = create_test_store().await;
-        let (docs, _embeddings) = create_test_docs();
+        let (docs, embeddings) = create_test_docs();
 
         // Insert documents
         store
             .upsert_document_metadata(&docs)
             .await
             .expect("Failed to upsert documents");
+
+        let line_embeddings: Vec<LineEmbedding> = docs
+            .iter()
+            .enumerate()
+            .map(|(i, doc)| LineEmbedding {
+                path: doc.path.clone(),
+                line_number: i as i32,
+                embedding: embeddings[i].clone(),
+            })
+            .collect();
+
+        store
+            .upsert_line_embeddings(&line_embeddings)
+            .await
+            .expect("Failed to upsert line embeddings");
 
         // Check stats
         let stats = store.get_stats().await.expect("Failed to get stats");

--- a/src/workspace/store.rs
+++ b/src/workspace/store.rs
@@ -914,7 +914,7 @@ mod tests {
             size_bytes: 100,
             mtime: 1000,
         };
-        let _initial_embedding = vec![vec![1.0, 2.0, 3.0, 4.0]];
+        let _initial_embedding = [vec![1.0, 2.0, 3.0, 4.0]];
 
         store
             .upsert_document_metadata(&[initial_doc])
@@ -934,7 +934,7 @@ mod tests {
             size_bytes: 200,
             mtime: 2000,
         };
-        let _updated_embedding = vec![vec![5.0, 6.0, 7.0, 8.0]];
+        let _updated_embedding = [vec![5.0, 6.0, 7.0, 8.0]];
 
         store
             .upsert_document_metadata(&[updated_doc])

--- a/src/workspace/store.rs
+++ b/src/workspace/store.rs
@@ -21,6 +21,13 @@ pub struct DocMeta {
     pub mtime: i64,
 }
 
+#[derive(Debug, Clone)]
+pub struct LineEmbedding {
+    pub path: String,
+    pub line_number: i32,
+    pub embedding: Vec<f32>,
+}
+
 impl DocMeta {
     pub fn id(&self) -> i32 {
         // Generate deterministic ID based on path hash for consistent upserts
@@ -31,9 +38,21 @@ impl DocMeta {
     }
 }
 
+impl LineEmbedding {
+    pub fn id(&self) -> i32 {
+        // Generate deterministic ID based on path + line number for consistent upserts
+        let mut hasher = DefaultHasher::new();
+        self.path.hash(&mut hasher);
+        self.line_number.hash(&mut hasher);
+        // Use absolute value to ensure positive ID, avoid i32::MIN edge case
+        (hasher.finish() as i32).abs().max(1)
+    }
+}
+
 #[derive(Debug, Clone)]
-pub struct RankedDoc {
+pub struct RankedLine {
     pub path: String,
+    pub line_number: i32,
     pub distance: f32,
 }
 
@@ -148,8 +167,21 @@ impl Store {
         Ok(existing)
     }
 
-    /// Delete documents by path
+    /// Delete documents and all associated line embeddings by path
     pub async fn delete_documents(&self, paths: &[String]) -> Result<()> {
+        if paths.is_empty() {
+            return Ok(());
+        }
+
+        // Delete from both tables to maintain synchronization
+        self.delete_document_metadata(paths).await?;
+        self.delete_line_embeddings(paths).await?;
+
+        Ok(())
+    }
+
+    /// Delete only document metadata by path (internal method)
+    async fn delete_document_metadata(&self, paths: &[String]) -> Result<()> {
         if paths.is_empty() {
             return Ok(());
         }
@@ -182,44 +214,56 @@ impl Store {
         Ok(())
     }
 
-    pub async fn upsert_documents(&self, metas: &[DocMeta], embeddings: &[Vec<f32>]) -> Result<()> {
-        // Validate inputs
-        if metas.len() != embeddings.len() {
-            bail!(
-                "metas and embeddings length mismatch: {} vs {}",
-                metas.len(),
-                embeddings.len()
-            );
+    /// Delete line embeddings by path
+    pub async fn delete_line_embeddings(&self, paths: &[String]) -> Result<()> {
+        if paths.is_empty() {
+            return Ok(());
         }
-        if embeddings.is_empty() {
-            return Ok(()); // nothing to do
+
+        let tables = self
+            .db
+            .table_names()
+            .execute()
+            .await
+            .context("failed to list LanceDB tables")?;
+        if !tables.contains(&"line_embeddings".to_string()) {
+            return Ok(()); // Nothing to delete
         }
-        let dim = embeddings[0].len();
-        if dim == 0 {
-            bail!("embeddings must be non-empty vectors");
+
+        let tbl = self
+            .db
+            .open_table("line_embeddings")
+            .execute()
+            .await
+            .context("failed to open 'line_embeddings' table")?;
+
+        // Delete in chunks
+        for chunk in paths.chunks(1000) {
+            let filter_expr = build_in_filter(chunk);
+            tbl.delete(&filter_expr).await.with_context(|| {
+                format!("failed to delete line embeddings with filter: {filter_expr}")
+            })?;
         }
-        if embeddings.iter().any(|e| e.len() != dim) {
-            bail!("all embeddings must have equal length");
+
+        Ok(())
+    }
+
+    /// Upsert document metadata for tracking file changes (no embeddings stored)
+    pub async fn upsert_document_metadata(&self, metas: &[DocMeta]) -> Result<()> {
+        if metas.is_empty() {
+            return Ok(());
         }
 
         // First, delete any existing documents with the same paths
         let paths: Vec<String> = metas.iter().map(|m| m.path.clone()).collect();
-        self.delete_documents(&paths).await?;
+        self.delete_document_metadata(&paths).await?;
 
-        // Define schema
+        // Define schema for metadata only
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, false),
             Field::new("path", DataType::Utf8, false),
             Field::new("size_bytes", DataType::UInt64, false),
             Field::new("mtime", DataType::Int64, false),
-            Field::new(
-                "vector",
-                DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Float32, true)),
-                    dim as i32,
-                ),
-                true,
-            ),
         ]));
 
         // Build a single RecordBatch
@@ -228,12 +272,6 @@ impl Store {
             StringArray::from(metas.iter().map(|m| m.path.as_str()).collect::<Vec<_>>());
         let size_bytes_array = UInt64Array::from_iter_values(metas.iter().map(|m| m.size_bytes));
         let mtime_array = Int64Array::from_iter_values(metas.iter().map(|m| m.mtime));
-        let vector_array = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
-            embeddings
-                .iter()
-                .map(|embedding| Some(embedding.iter().cloned().map(Some))),
-            dim as i32,
-        );
 
         let batch = RecordBatch::try_new(
             schema.clone(),
@@ -242,7 +280,6 @@ impl Store {
                 Arc::new(path_array),
                 Arc::new(size_bytes_array),
                 Arc::new(mtime_array),
-                Arc::new(vector_array),
             ],
         )?;
 
@@ -278,26 +315,116 @@ impl Store {
                 .context("failed to append batches to 'documents' table")?;
         }
 
-        // Handle index creation/optimization after data is added
-        self.ensure_vector_index().await?;
+        Ok(())
+    }
+
+    /// Upsert line-level embeddings for documents
+    pub async fn upsert_line_embeddings(&self, line_embeddings: &[LineEmbedding]) -> Result<()> {
+        if line_embeddings.is_empty() {
+            return Ok(());
+        }
+
+        let dim = line_embeddings[0].embedding.len();
+        if dim == 0 {
+            bail!("embeddings must be non-empty vectors");
+        }
+        if line_embeddings.iter().any(|e| e.embedding.len() != dim) {
+            bail!("all embeddings must have equal length");
+        }
+
+        // First, delete any existing lines with the same paths
+        let paths: Vec<String> = line_embeddings.iter().map(|le| le.path.clone()).collect();
+        let unique_paths: std::collections::HashSet<String> = paths.into_iter().collect();
+        let unique_paths: Vec<String> = unique_paths.into_iter().collect();
+        self.delete_line_embeddings(&unique_paths).await?;
+
+        // Define schema for line embeddings
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("path", DataType::Utf8, false),
+            Field::new("line_number", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    dim as i32,
+                ),
+                true,
+            ),
+        ]));
+
+        // Build RecordBatch
+        let id_array = Int32Array::from_iter_values(line_embeddings.iter().map(|le| le.id()));
+        let path_array = StringArray::from(line_embeddings.iter().map(|le| le.path.as_str()).collect::<Vec<_>>());
+        let line_number_array = Int32Array::from_iter_values(line_embeddings.iter().map(|le| le.line_number));
+        let vector_array = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+            line_embeddings
+                .iter()
+                .map(|le| Some(le.embedding.iter().cloned().map(Some))),
+            dim as i32,
+        );
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(id_array),
+                Arc::new(path_array),
+                Arc::new(line_number_array),
+                Arc::new(vector_array),
+            ],
+        )?;
+
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+
+        // Create or append to line_embeddings table
+        let tables = self
+            .db
+            .table_names()
+            .execute()
+            .await
+            .context("failed to list LanceDB tables")?;
+        let table_existed = tables.contains(&"line_embeddings".to_string());
+
+        if !table_existed {
+            self.db
+                .create_table("line_embeddings", Box::new(batches))
+                .execute()
+                .await
+                .context("failed to create 'line_embeddings' table")?;
+        } else {
+            let tbl = self
+                .db
+                .open_table("line_embeddings")
+                .execute()
+                .await
+                .context("failed to open 'line_embeddings' table")?;
+            tbl.add(Box::new(batches))
+                .execute()
+                .await
+                .context("failed to append batches to 'line_embeddings' table")?;
+        }
+
+        // Ensure vector index exists
+        self.ensure_line_vector_index().await?;
 
         Ok(())
     }
 
-    /// Ensures vector index exists and is optimized for current data size
-    async fn ensure_vector_index(&self) -> Result<()> {
+
+    /// Ensures vector index exists for line embeddings table
+    async fn ensure_line_vector_index(&self) -> Result<()> {
         let tbl = self
             .db
-            .open_table("documents")
+            .open_table("line_embeddings")
             .execute()
             .await
-            .context("failed to open 'documents' table")?;
+            .context("failed to open 'line_embeddings' table")?;
 
         // Check if vector index exists
         let indices = tbl
             .list_indices()
             .await
-            .context("failed to list indices for 'documents' table")?;
+            .context("failed to list indices for 'line_embeddings' table")?;
         let has_vector_index = indices
             .iter()
             .any(|idx| idx.columns.contains(&"vector".to_string()));
@@ -317,7 +444,7 @@ impl Store {
                         // Log a warning but continue - the database will still work without the index
                         // It will just use brute-force search instead of approximate search
                         eprintln!(
-                            "Warning: Skipping vector index creation due to insufficient data (need at least 256 rows for PQ index). Database will use brute-force search."
+                            "Warning: Skipping line embeddings vector index creation due to insufficient data (need at least 256 rows for PQ index). Database will use brute-force search."
                         );
                     } else if error_msg.contains("No space left on device") {
                         return Err(anyhow!(
@@ -339,7 +466,7 @@ impl Store {
             if tbl.optimize(Default::default()).await.is_err() {
                 // If optimization fails, we could fall back to recreating the index
                 // but for now just log and continue
-                eprintln!("Warning: Failed to optimize vector index");
+                eprintln!("Warning: Failed to optimize line embeddings vector index");
             }
         }
 
@@ -383,10 +510,16 @@ impl Store {
         let total_documents = batches.iter().map(|batch| batch.num_rows()).sum();
 
         // Check if vector index exists
-        let indices = tbl
+        let line_tbl = self
+            .db
+            .open_table("line_embeddings")
+            .execute()
+            .await
+            .context("failed to open 'line_embeddings' table")?;
+        let indices = line_tbl
             .list_indices()
             .await
-            .context("failed to list indices for 'documents' table")?;
+            .context("failed to list indices for 'line_embeddings' table")?;
         let has_vector_index = indices
             .iter()
             .any(|idx| idx.columns.contains(&"vector".to_string()));
@@ -454,152 +587,132 @@ impl Store {
         Ok(paths)
     }
 
-    pub async fn ann_filter_top_k(
+    /// Search line embeddings directly for precise results
+    pub async fn search_line_embeddings(
         &self,
         query_vec: &[f32],
         subset_paths: &[String],
-        doc_top_k: usize,
-        in_batch_size: usize,
-    ) -> Result<Vec<RankedDoc>> {
-        // Use good default parameters for balanced recall/latency
-        // refine_factor=5: improves recall by re-ranking more candidates
-        // nprobes=10: searches more index partitions for better recall
-        self.ann_filter_top_k_with_params(
-            query_vec,
-            subset_paths,
-            doc_top_k,
-            in_batch_size,
-            Some(5),
-            Some(10),
-        )
-        .await
-    }
-
-    /// ANN search with configurable search parameters for recall/latency tradeoff
-    pub async fn ann_filter_top_k_with_params(
-        &self,
-        query_vec: &[f32],
-        subset_paths: &[String],
-        doc_top_k: usize,
-        in_batch_size: usize,
-        refine_factor: Option<u32>,
-        nprobes: Option<u32>,
-    ) -> Result<Vec<RankedDoc>> {
+        top_k: usize,
+        max_distance: Option<f32>,
+    ) -> Result<Vec<RankedLine>> {
         // Short-circuit on empty subsets
-        if subset_paths.is_empty() || doc_top_k == 0 {
+        if subset_paths.is_empty() || top_k == 0 {
+            return Ok(Vec::new());
+        }
+
+        let tables = self
+            .db
+            .table_names()
+            .execute()
+            .await
+            .context("failed to list LanceDB tables")?;
+        if !tables.contains(&"line_embeddings".to_string()) {
             return Ok(Vec::new());
         }
 
         let tbl = self
             .db
-            .open_table("documents")
+            .open_table("line_embeddings")
             .execute()
             .await
-            .context("failed to open 'documents' table")?;
+            .context("failed to open 'line_embeddings' table")?;
 
-        // Aggregate best (lowest) distance per path across batches
-        let mut best_by_path: HashMap<String, f32> = HashMap::new();
+        let mut all_results = Vec::new();
 
-        // Chunk the subset paths to avoid overly long IN(...) filters
-        for chunk in subset_paths.chunks(in_batch_size.max(1)) {
+        // Search in chunks to avoid overly long IN(...) filters
+        for chunk in subset_paths.chunks(1000) {
             let filter_expr = build_in_filter(chunk);
 
-            let mut query = tbl
+            let query = tbl
                 .query()
                 .only_if(filter_expr)
                 .nearest_to(query_vec)
-                .context("failed to set nearest_to on query")?
+                .context("failed to set nearest_to on line embeddings query")?
                 .distance_type(lancedb::DistanceType::Cosine)
-                .limit(doc_top_k);
-
-            // Apply search parameters for better recall/latency control
-            if let Some(rf) = refine_factor {
-                query = query.refine_factor(rf);
-            }
-            if let Some(np) = nprobes {
-                query = query.nprobes(np as usize);
-            }
+                .limit(top_k * 2); // Get more results per chunk to improve global ranking
 
             let stream = query
                 .execute()
                 .await
-                .context("failed to execute ANN query batch")?;
+                .context("failed to execute line embeddings search")?;
 
             let batches: Vec<RecordBatch> = stream
                 .try_collect()
                 .await
-                .context("failed to collect ANN query batches")?;
+                .context("failed to collect line embeddings search batches")?;
 
             for batch in batches {
                 let schema = batch.schema();
 
-                // Locate indices for path and distance columns dynamically
                 let path_idx = schema
                     .index_of("path")
-                    .context("missing 'path' column in ANN result schema")?;
+                    .context("missing 'path' column in line embeddings result")?;
+                let line_number_idx = schema
+                    .index_of("line_number")
+                    .context("missing 'line_number' column in line embeddings result")?;
                 let distance_idx = schema
                     .index_of("_distance")
                     .or_else(|_| schema.index_of("distance"))
-                    .context("missing 'distance' column in ANN result schema")?;
+                    .context("missing 'distance' column in line embeddings result")?;
 
-                let path_col = batch.column(path_idx);
-                let dist_col = batch.column(distance_idx);
-
-                let path_array = path_col
+                let path_array = batch
+                    .column(path_idx)
                     .as_any()
                     .downcast_ref::<StringArray>()
-                    .ok_or_else(|| anyhow!("unexpected type for 'path' column in ANN result"))?;
+                    .ok_or_else(|| anyhow!("unexpected type for 'path' column"))?;
+                let line_number_array = batch
+                    .column(line_number_idx)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .ok_or_else(|| anyhow!("unexpected type for 'line_number' column"))?;
+                let dist_col = batch.column(distance_idx);
 
-                // Distance may be f32 or f64 depending on engine; handle both
+                // Handle both f32 and f64 distance types
                 if let Some(dist_array) = dist_col.as_any().downcast_ref::<Float32Array>() {
                     for i in 0..batch.num_rows() {
-                        let path = path_array.value(i).to_string();
                         let distance = dist_array.value(i);
-                        match best_by_path.get_mut(&path) {
-                            Some(existing) => {
-                                if distance < *existing {
-                                    *existing = distance;
-                                }
-                            }
-                            None => {
-                                best_by_path.insert(path, distance);
+                        if let Some(max_dist) = max_distance {
+                            if distance > max_dist {
+                                continue;
                             }
                         }
+                        
+                        all_results.push(RankedLine {
+                            path: path_array.value(i).to_string(),
+                            line_number: line_number_array.value(i),
+                            distance,
+                        });
                     }
                 } else if let Some(dist_array) = dist_col.as_any().downcast_ref::<Float64Array>() {
                     for i in 0..batch.num_rows() {
-                        let path = path_array.value(i).to_string();
-                        let distance_f32 = dist_array.value(i) as f32;
-                        match best_by_path.get_mut(&path) {
-                            Some(existing) => {
-                                if distance_f32 < *existing {
-                                    *existing = distance_f32;
-                                }
-                            }
-                            None => {
-                                best_by_path.insert(path, distance_f32);
+                        let distance = dist_array.value(i) as f32;
+                        if let Some(max_dist) = max_distance {
+                            if distance > max_dist {
+                                continue;
                             }
                         }
+                        
+                        all_results.push(RankedLine {
+                            path: path_array.value(i).to_string(),
+                            line_number: line_number_array.value(i),
+                            distance,
+                        });
                     }
                 } else {
-                    bail!("unsupported distance column type");
+                    bail!("unsupported distance column type in line embeddings search");
                 }
             }
         }
 
-        // Collect, sort by distance, and take global top-k
-        let mut ranked: Vec<RankedDoc> = best_by_path
-            .into_iter()
-            .map(|(path, distance)| RankedDoc { path, distance })
-            .collect();
-        ranked.sort_by(|a, b| {
+        // Sort by distance and take global top-k
+        all_results.sort_by(|a, b| {
             a.distance
                 .partial_cmp(&b.distance)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
-        ranked.truncate(doc_top_k);
+        all_results.truncate(top_k);
 
-        Ok(ranked)
+        Ok(all_results)
     }
 }
 
@@ -669,11 +782,11 @@ mod tests {
     #[tokio::test]
     async fn test_upsert_documents_and_stats() {
         let (store, _temp_dir) = create_test_store().await;
-        let (docs, embeddings) = create_test_docs();
+        let (docs, _embeddings) = create_test_docs();
 
         // Insert documents
         store
-            .upsert_documents(&docs, &embeddings)
+            .upsert_document_metadata(&docs)
             .await
             .expect("Failed to upsert documents");
 
@@ -691,7 +804,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_all_document_paths() {
         let (store, _temp_dir) = create_test_store().await;
-        let (docs, embeddings) = create_test_docs();
+        let (docs, _embeddings) = create_test_docs();
 
         // Initially should be empty
         let paths = store
@@ -702,7 +815,7 @@ mod tests {
 
         // Insert documents
         store
-            .upsert_documents(&docs, &embeddings)
+            .upsert_document_metadata(&docs)
             .await
             .expect("Failed to upsert documents");
 
@@ -721,11 +834,11 @@ mod tests {
     #[tokio::test]
     async fn test_get_existing_docs() {
         let (store, _temp_dir) = create_test_store().await;
-        let (docs, embeddings) = create_test_docs();
+        let (docs, _embeddings) = create_test_docs();
 
         // Insert documents
         store
-            .upsert_documents(&docs, &embeddings)
+            .upsert_document_metadata(&docs)
             .await
             .expect("Failed to upsert documents");
 
@@ -755,11 +868,11 @@ mod tests {
     #[tokio::test]
     async fn test_delete_documents() {
         let (store, _temp_dir) = create_test_store().await;
-        let (docs, embeddings) = create_test_docs();
+        let (docs, _embeddings) = create_test_docs();
 
         // Insert documents
         store
-            .upsert_documents(&docs, &embeddings)
+            .upsert_document_metadata(&docs)
             .await
             .expect("Failed to upsert documents");
 
@@ -786,68 +899,7 @@ mod tests {
         assert!(remaining_paths.contains(&"/test/doc2.txt".to_string()));
     }
 
-    #[tokio::test]
-    async fn test_ann_filter_top_k() {
-        let (store, _temp_dir) = create_test_store().await;
-        let (docs, embeddings) = create_test_docs();
 
-        // Insert documents
-        store
-            .upsert_documents(&docs, &embeddings)
-            .await
-            .expect("Failed to upsert documents");
-
-        // Test ANN search
-        let query_vec = vec![0.2, 0.3, 0.4, 0.5];
-        let subset_paths = vec![
-            "/test/doc1.txt".to_string(),
-            "/test/doc2.txt".to_string(),
-            "/test/doc3.txt".to_string(),
-        ];
-
-        let results = store
-            .ann_filter_top_k(&query_vec, &subset_paths, 2, 1000)
-            .await
-            .expect("Failed to perform ANN search");
-
-        // Should return results (exact ranking depends on embeddings)
-        assert!(!results.is_empty());
-        assert!(results.len() <= 2);
-
-        // Results should be sorted by distance
-        for i in 1..results.len() {
-            assert!(results[i - 1].distance <= results[i].distance);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_ann_filter_top_k_with_custom_params() {
-        let (store, _temp_dir) = create_test_store().await;
-        let (docs, embeddings) = create_test_docs();
-
-        // Insert documents
-        store
-            .upsert_documents(&docs, &embeddings)
-            .await
-            .expect("Failed to upsert documents");
-
-        // Test ANN search with custom parameters
-        let query_vec = vec![0.2, 0.3, 0.4, 0.5];
-        let subset_paths = vec![
-            "/test/doc1.txt".to_string(),
-            "/test/doc2.txt".to_string(),
-            "/test/doc3.txt".to_string(),
-        ];
-
-        let results = store
-            .ann_filter_top_k_with_params(&query_vec, &subset_paths, 2, 1000, Some(3), Some(5))
-            .await
-            .expect("Failed to perform ANN search with custom params");
-
-        // Should return results
-        assert!(!results.is_empty());
-        assert!(results.len() <= 2);
-    }
 
     #[tokio::test]
     async fn test_upsert_replaces_existing() {
@@ -859,10 +911,10 @@ mod tests {
             size_bytes: 100,
             mtime: 1000,
         };
-        let initial_embedding = vec![vec![1.0, 2.0, 3.0, 4.0]];
+        let _initial_embedding = vec![vec![1.0, 2.0, 3.0, 4.0]];
 
         store
-            .upsert_documents(&[initial_doc], &initial_embedding)
+            .upsert_document_metadata(&[initial_doc])
             .await
             .expect("Failed to insert initial document");
 
@@ -879,10 +931,10 @@ mod tests {
             size_bytes: 200,
             mtime: 2000,
         };
-        let updated_embedding = vec![vec![5.0, 6.0, 7.0, 8.0]];
+        let _updated_embedding = vec![vec![5.0, 6.0, 7.0, 8.0]];
 
         store
-            .upsert_documents(&[updated_doc], &updated_embedding)
+            .upsert_document_metadata(&[updated_doc])
             .await
             .expect("Failed to update document");
 


### PR DESCRIPTION
So, document-level filtering might be too big-brained. 

Trying a beta.2 approach where instead we purely persist line embeddings

I also considered swapping lancedb with sqlite, but with line-level embeddings we will quickly blow past the scaling limits of sqlite