### PR TITLE
Fix search binary build without workspace

### DIFF
--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -47,6 +47,7 @@ pub struct Document {
     embeddings: Vec<Vec<f32>>,
 }
 
+#[cfg(feature = "workspace")]
 #[derive(Debug)]
 pub struct DocumentInfo {
     filename: String,
@@ -54,6 +55,7 @@ pub struct DocumentInfo {
     meta: DocMeta,
 }
 
+#[cfg(feature = "workspace")]
 #[derive(Debug)]
 pub enum DocumentState {
     Unchanged(String),     // Just the filename, no need to process


### PR DESCRIPTION
## Description

- gate `DocumentInfo` and `DocumentState` behind the `workspace` feature so the `search` binary builds when installed without workspace support

## Type of Change

Label suggestion: `bug`

## Testing

- [x] I have tested my changes locally
- [ ] I have added tests for new functionality (if applicable)
- [ ] All existing tests pass

_Local notes_: `cargo fmt --all -- --check`, `cargo clippy --no-default-features --features search`

## Checklist

- [x] My code passes `cargo clippy` and `cargo fmt`
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
