### PR TITLE
Add versioning support so that embedding models can be updated without breakage

### DIFF
--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -9,7 +9,7 @@ use std::io::{self, BufRead, IsTerminal};
 #[cfg(feature = "workspace")]
 use semtools::workspace::{
     Workspace,
-    store::{DocMeta, LineEmbedding, RankedLine, Store, CURRENT_EMBEDDING_VERSION},
+    store::{CURRENT_EMBEDDING_VERSION, DocMeta, LineEmbedding, RankedLine, Store},
 };
 
 const MODEL_NAME: &str = "minishlab/potion-multilingual-128M";
@@ -803,7 +803,7 @@ mod tests {
                     path: path.clone(),
                     size_bytes: 10, // Different from actual size
                     mtime: 1000,    // Old timestamp
-                    _version: 1, // simulate old version
+                    _version: 1,    // simulate old version
                 };
                 docs.push(doc_meta);
                 // embeddings.push(vec![1.0, 2.0, 3.0, 4.0]); // Dummy embedding - not needed anymore

--- a/src/workspace/store.rs
+++ b/src/workspace/store.rs
@@ -141,7 +141,6 @@ impl Store {
                 // Optional version column (backwards compatibility)
                 let version_idx = schema.index_of("_version").ok();
 
-
                 let path_array = batch
                     .column(path_idx)
                     .as_any()
@@ -177,10 +176,7 @@ impl Store {
                     let path = path_array.value(i).to_string();
                     let size_bytes = size_array.value(i);
                     let mtime = mtime_array.value(i);
-                    let version = version_accessor
-                        .as_ref()
-                        .map(|v| v[i])
-                        .unwrap_or(1); // default for legacy rows
+                    let version = version_accessor.as_ref().map(|v| v[i]).unwrap_or(1); // default for legacy rows
 
                     existing.insert(
                         path.clone(),
@@ -304,7 +300,8 @@ impl Store {
             StringArray::from(metas.iter().map(|m| m.path.as_str()).collect::<Vec<_>>());
         let size_bytes_array = UInt64Array::from_iter_values(metas.iter().map(|m| m.size_bytes));
         let mtime_array = Int64Array::from_iter_values(metas.iter().map(|m| m.mtime));
-        let version_array = arrow_array::UInt32Array::from_iter_values(metas.iter().map(|m| m._version));
+        let version_array =
+            arrow_array::UInt32Array::from_iter_values(metas.iter().map(|m| m._version));
 
         let batch = RecordBatch::try_new(
             schema.clone(),


### PR DESCRIPTION
Stored documents in a workspace are now versioned. If the library changes the embedding model, we can detect this and re-embed