### PR TITLE
Add Homebrew installation support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
             target: aarch64-pc-windows-msvc
           - os: macos-latest
             target: aarch64-apple-darwin
+          - os: macos-13
+            target: x86_64-apple-darwin
 
     steps:
     - name: Checkout code

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,88 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-formula:
+    name: Update Formula SHA256 values
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: main
+
+    - name: Wait for release assets
+      run: sleep 30
+
+    - name: Extract version from tag
+      id: version
+      run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+    - name: Download release assets and compute checksums
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ steps.version.outputs.VERSION }}"
+        cd /tmp
+
+        declare -A TARGETS=(
+          ["ARM64_DARWIN"]="semtools-aarch64-apple-darwin.tar.gz"
+          ["X86_64_DARWIN"]="semtools-x86_64-apple-darwin.tar.gz"
+          ["ARM64_LINUX"]="semtools-aarch64-unknown-linux-gnu.tar.gz"
+          ["X86_64_LINUX"]="semtools-x86_64-unknown-linux-gnu.tar.gz"
+        )
+
+        for KEY in "${!TARGETS[@]}"; do
+          ASSET="${TARGETS[$KEY]}"
+          URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/${ASSET}"
+          echo "Downloading ${ASSET}..."
+          if curl -fsSL -o "${ASSET}" "${URL}"; then
+            SHA=$(sha256sum "${ASSET}" | cut -d' ' -f1)
+            echo "${KEY}_SHA=${SHA}" >> $GITHUB_ENV
+            echo "  ${KEY}: ${SHA}"
+          else
+            echo "  ${KEY}: asset not available, skipping"
+            echo "${KEY}_SHA=UNAVAILABLE" >> $GITHUB_ENV
+          fi
+        done
+
+    - name: Update formula
+      run: |
+        VERSION="${{ steps.version.outputs.VERSION }}"
+        FORMULA="Formula/semtools.rb"
+
+        sed -i "s/version \".*\"/version \"${VERSION}\"/" "$FORMULA"
+
+        if [ "$ARM64_DARWIN_SHA" != "UNAVAILABLE" ]; then
+          # Match the sha256 line after aarch64-apple-darwin url
+          sed -i "/aarch64-apple-darwin/{n;s/sha256 \".*\"/sha256 \"${ARM64_DARWIN_SHA}\"/}" "$FORMULA"
+        fi
+
+        if [ "$X86_64_DARWIN_SHA" != "UNAVAILABLE" ]; then
+          sed -i "/x86_64-apple-darwin/{n;s/sha256 \".*\"/sha256 \"${X86_64_DARWIN_SHA}\"/}" "$FORMULA"
+        fi
+
+        if [ "$ARM64_LINUX_SHA" != "UNAVAILABLE" ]; then
+          sed -i "/aarch64-unknown-linux-gnu/{n;s/sha256 \".*\"/sha256 \"${ARM64_LINUX_SHA}\"/}" "$FORMULA"
+        fi
+
+        if [ "$X86_64_LINUX_SHA" != "UNAVAILABLE" ]; then
+          sed -i "/x86_64-unknown-linux-gnu/{n;s/sha256 \".*\"/sha256 \"${X86_64_LINUX_SHA}\"/}" "$FORMULA"
+        fi
+
+        echo "Updated formula:"
+        cat "$FORMULA"
+
+    - name: Commit and push
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add Formula/semtools.rb
+        git diff --cached --quiet && echo "No changes" && exit 0
+        git commit -m "Update Homebrew formula for v${{ steps.version.outputs.VERSION }}"
+        git push

--- a/Formula/semtools.rb
+++ b/Formula/semtools.rb
@@ -1,0 +1,34 @@
+class Semtools < Formula
+  desc "Semantic search and document parsing tools for the command-line"
+  homepage "https://github.com/run-llama/semtools"
+  version "3.0.1"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/run-llama/semtools/releases/download/v#{version}/semtools-aarch64-apple-darwin.tar.gz"
+      sha256 "e43f20a5dc65e94b883158e7aca6dd11591840adc00db885a50024c38473f72b"
+    else
+      url "https://github.com/run-llama/semtools/releases/download/v#{version}/semtools-x86_64-apple-darwin.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000" # updated on release
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/run-llama/semtools/releases/download/v#{version}/semtools-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "b7a4dccd10f3ad7b544e65943216304fa59195f486d06e25ace6e2ade38a4d2c"
+    else
+      url "https://github.com/run-llama/semtools/releases/download/v#{version}/semtools-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "f13d60ccbf64a9a7a9d8860d60f2b4fdf86a445d737220c5286b92e7eb87f54d"
+    end
+  end
+
+  def install
+    bin.install "semtools"
+  end
+
+  test do
+    assert_match "Usage:", shell_output("#{bin}/semtools --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Prerequisites:
 
 Install:
 
-You can install `semtools` via npm:
+You can install `semtools` via Homebrew (macOS and Linux):
+
+```bash
+brew tap run-llama/semtools https://github.com/run-llama/semtools
+brew install semtools
+```
+
+Or via npm:
 
 ```bash
 npm i -g @llamaindex/semtools


### PR DESCRIPTION
## Summary

- Add `Formula/semtools.rb` Homebrew formula that downloads prebuilt binaries per-platform (macOS ARM/Intel, Linux ARM/x86_64)
- Add `update-homebrew.yml` GitHub Actions workflow that automatically updates formula SHA256 checksums when a new release is published
- Add `x86_64-apple-darwin` (Intel Mac) target to the release build matrix so Homebrew users on Intel Macs get a native binary
- Update README with `brew tap` / `brew install` instructions

## How it works

With the formula in this repo, users install via:
```bash
brew tap run-llama/semtools https://github.com/run-llama/semtools
brew install semtools
```

## Simpler installation with a tap repo

To enable the shorter:
```bash
brew install run-llama/tap/semtools
```

You would need to create a `run-llama/homebrew-tap` repo containing just the `Formula/` directory. Homebrew auto-resolves `run-llama/tap` to `github.com/run-llama/homebrew-tap`. Steps:

1. Create a new repo `run-llama/homebrew-tap`
2. Copy `Formula/semtools.rb` into it
3. Update the `update-homebrew.yml` workflow to push formula updates to that repo instead (requires a PAT or deploy key with write access to the tap repo)

## Test plan

- [x] Formula passes `brew style` (rubocop linting)
- [x] Formula passes `brew audit`
- [x] Formula installs successfully via `brew install` on Linux x86_64
- [x] Installed binary runs correctly (`semtools --help`)
- [x] Formula test passes (`brew test`)